### PR TITLE
Replace `hold` by `held` in the ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ expressions, in which you can use the literal's keys as JS variables.
 
 # Dev intro
 
-The entirety of the templating system is hold in the `fleau.js` code file. There
+The entirety of the templating system is held in the `fleau.js` code file. There
 are tests in the `test/` directory, which you run using `make test`.
 
 `fleau.js` starts with a series of helper functions which are really meant to


### PR DESCRIPTION
It makes more sense to me to say:

> The entirety of the templating system is held in the `fleau.js` code file. 
